### PR TITLE
strictObject for schema declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@cross-check/core": "^0.9.0",
-    "@cross-check/dsl": "^0.9.2",
+    "@cross-check/dsl": "^0.9.3",
     "no-show": "^0.6.2",
     "ts-std": "^0.6.2"
   }

--- a/src/types/fundamental/dictionary.ts
+++ b/src/types/fundamental/dictionary.ts
@@ -10,7 +10,7 @@ function buildSchemaValidation(desc: Dict<Type>): ValidationBuilder<unknown> {
     obj[key] = value!.validation();
   }
 
-  return validators.object(obj);
+  return validators.stricObject(obj);
 }
 
 export interface DictionaryType extends Type {
@@ -23,7 +23,7 @@ export class DictionaryImpl implements DictionaryType {
     private typeName: string | undefined,
     readonly isRequired: boolean,
     readonly base: Option<DictionaryType>
-  ) {}
+  ) { }
 
   required(isRequired = true): Type {
     return new DictionaryImpl(this.inner, this.typeName, isRequired, this.base);

--- a/src/types/fundamental/dictionary.ts
+++ b/src/types/fundamental/dictionary.ts
@@ -10,7 +10,7 @@ function buildSchemaValidation(desc: Dict<Type>): ValidationBuilder<unknown> {
     obj[key] = value!.validation();
   }
 
-  return validators.stricObject(obj);
+  return validators.strictObject(obj);
 }
 
 export interface DictionaryType extends Type {


### PR DESCRIPTION
This will make schema validations fail if all fields are not provided, and it will also fail if any extra fields are provided.